### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '13', '15' ]
+        java: [ '8', '8.0.192', '11', '11.0.3', '13', '15' ]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Build with Gradle

--- a/.github/workflows/mavencentral.yml
+++ b/.github/workflows/mavencentral.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Build and Upload to the Maven Central Repository


### PR DESCRIPTION
in GH actions. The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. As best practice I've added fixed versions. 